### PR TITLE
Add option to change volume of stimuli.

### DIFF
--- a/HeadphoneCheck.js
+++ b/HeadphoneCheck.js
@@ -29,6 +29,7 @@ Contact Ray Gonzalez raygon@mit.edu or Kevin J. P. Woods kwoods@mit.edu
   // NOTE: DON'T CHANGE VALUES HERE. Use a similar config object to
   // override any default values you wish to change.
   var headphoneCheckDefaultConfig = {jsonPath: undefined,
+                              audioVolume: 1.0,
                               totalTrials: 6,
                               trialsPerPage: 3,
                               correctThreshold: 5/6,
@@ -306,9 +307,9 @@ Contact Ray Gonzalez raygon@mit.edu or Kevin J. P. Woods kwoods@mit.edu
 
     //add in the audio source
     $('<audio/>', {
-        id: 'hc-audio-' + stimID,
-        src: stimFile
-      }).appendTo($('#' + divID));
+      id: 'hc-audio-' + stimID,
+      src: stimFile
+    }).appendTo($('#' + divID));
 
     if (headphoneCheckConfig.debug) {
       $('<div/>', {
@@ -437,6 +438,7 @@ Contact Ray Gonzalez raygon@mit.edu or Kevin J. P. Woods kwoods@mit.edu
     $('#hc-play-button-border-' + stimID).css('border-color', trialBackgroundColor);
 
     // play and set state
+    $('#' + stimFile).get(0).volume = headphoneCheckConfig.audioVolume;
     $('#' + stimFile).get(0).play();
     st_isPlaying = true;
     // hack to disable responding during playback
@@ -466,6 +468,7 @@ Contact Ray Gonzalez raygon@mit.edu or Kevin J. P. Woods kwoods@mit.edu
       st_isPlaying = false;
       $('#hc-calibration-continue-button').prop('disabled', false);
     });
+    $('#' + calibrationID).get(0).volume = headphoneCheckConfig.audioVolume;
     $('#' + calibrationID).get(0).play();
     st_isPlaying = true;
   }

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ To customize the headphone check, you can pass in an object of property:value pa
 headphoneCheckDefaultConfig = 
 {
   jsonPath: undefined, // URL to json file containing stimulus/resource URLs.
+  audioVolume: 1.0, // Volume of the stimuli and the calibration sound, relative to their default (e.g., a setting of 0.5 plays the sounds at half volume).
   totalTrials: 6, // Total number of trials.
   trialsPerPage: 3, // Number of trials to render on a single page.
   correctThreshold: 5/6, // Minimum percentage of correct responses required to pass the headphone screening.


### PR DESCRIPTION
Hello, thanks for sharing this tool! It is proving really helpful for an online auditory experiment I am getting ready to run.

While adding it to the study, I noticed that the sounds were louder than my experimental stimuli. So, I added `headphoneCheck[Default]Config.audioVolume` so that I could adjust the volume programmatically and still use the default stimuli. I figured this might be useful to others, too, hence the pull request. :smiley: 

Before a stimulus is played, the `HTMLMediaElement.volume` property is set to the specified value. The default value is set to 1.0, meaning it will play at 100% volume. (I tried to set the `volume` property when each stimulus was created, but I found that it didn't actually change the volume at all, for some reason.)

I also updated the README with a description of the property.

Thank you, and please let me know if there is anything I should change!